### PR TITLE
Bugfix in mockAPI var not defined on line 25

### DIFF
--- a/client/src/mockAPI.js
+++ b/client/src/mockAPI.js
@@ -22,7 +22,7 @@ export function getUser(username) {
 
 // Get a single user by id
 export function getUserById(id) {
-    let foundUser = USERS.find((id) => 
+    let foundUser = USERS.find((user) => 
         user.id === id
         );
     if (foundUser !== undefined) {


### PR DESCRIPTION
There was a bug in mockAPI.js 
The error did not show up when I ran npm start a few days a go before I pushed the last commit.
However today it gave me an error.
Variable 'user' not defined on line 26.
I changed the parameter on line 25 from 'id' to 'user'. 

The bug is now fixed.