### PR TITLE
Bugfix show multiple events in entry

### DIFF
--- a/client/src/components/AddEntryPage.js
+++ b/client/src/components/AddEntryPage.js
@@ -3,9 +3,13 @@ import {useDispatch, useSelector} from 'react-redux';
 import {Link, useNavigate} from "react-router-dom";
 import {addEntry} from '../store';
 
+// This is used to temporally store the events of the entry before submit.
+const events = [];
+
 export default function AddEntryPage() {
     const dispatch = useDispatch();
     const navigate = useNavigate();
+    // Get the username from the global state.
     const username = useSelector(state => state.userData.userInfo.username);
 
     // Values of all the input boxes
@@ -13,16 +17,99 @@ export default function AddEntryPage() {
     const [entryState, setEntryState] = useState({
         type: "Stress",
         level: 1,
-        event: "work",
+        event: [],
         note: "Your note here..."
     });
 
-    // Handles changes in the input boxes (Saves user input to the React State manager)
-    // e is the event that is accociated with the input box that the user is inputting/using
-    // make sure to keep the name attribute of html element the same as the key in state object
-    const handleChange = (e) => {
-        //const value = evt.target.type === "checkbox" ? e.target.checked : e.target.value;
+    // A boolean array for checking the click or unclicked state of the events checkboxes
+    const [isCheckedEventsArray, setIsCheckedEventsArray] = useState(
+        new Array(6).fill(false)
+    );
+
+    /*
+     Handles changes in the input boxes (Saves user input to the React State manager)
+     e is the event that is accociated with the input box that the user is inputting/using
+     make sure to keep the name attribute of html element the same as the key in state object
+     checkedPosition is the index of the checkboxes
+    */
+    const handleChange = (e, checkedPosition=0) => {
+        
+        // Handle the checkboxes.
+        if (e.target.name === "event") {
+            // Checks or unchecks each checkbox and maps it to an array of booleans.
+            const updatedIsCheckedEventsArray = isCheckedEventsArray.map((checkBoxState, index) =>
+                index === checkedPosition ? !checkBoxState : checkBoxState
+            );
+            setIsCheckedEventsArray(updatedIsCheckedEventsArray);
+            
+            //let indexAttr = e.target.getAttribute('index');
+
+            console.log("==================================");
+            console.log("BEFORE");
+            console.log(updatedIsCheckedEventsArray)
+            console.log(e.target.name);
+            console.log("events:");
+            console.log(events);
+            //console.log(indexAttr);
+            //console.log(parseInt(indexAttr));
+
+            // Transforms the array of booleans of the checkboxes to an array with values for each event.
+            // checkBoxState is equal to the value of each item of boolean array
+            // The index is equal to the index of the boolean array.
+            updatedIsCheckedEventsArray.forEach( (checkBoxState, index) => {
+                // Explicitly checking for true value to not make myself confused.
+                // same as if(checkBoxState) {}
+                console.log("index: " + index);
+                if (checkBoxState === true) {
+                    // Each index corresponds to the checked or unchecked state of each of the 6 checkboxes.
+                    switch(index) {
+                        case 0:
+                            events[0] = "family";
+                            break;
+                        case 1:
+                            events[1] = "relationship";
+                            break;
+                        case 2:
+                            events[2] = "work";
+                            break;
+                        case 3:
+                            events[3] = "significant";
+                            break;
+                        case 4:
+                            events[4] = "trauma";
+                            break;
+                        case 5:
+                            events[5] = "unknown";
+                            break;
+                        default: 
+                            return 0;
+                    }
+                }
+                else {
+                    events[index] = null;
+                }
+            });
+
+            console.log("==================================");
+            console.log("AFTER");
+            console.log(updatedIsCheckedEventsArray)
+            console.log(e.target.name);
+            console.log("events:");
+            console.log(events);
+            
+            // Set the event variable equal to the events array.
+            setEntryState({
+                ...entryState,
+                [e.target.name]: events
+            });
+
+            // Escape the function with no errors 
+            // This is to prevent the state from being written over by the next setEentryState below this code
+            return 0;
+        } 
+        // Get the value of the input boxes.
         const value = e.target.value;
+        // This is used to set the value of all the other input boxes except the checkboxes.
         setEntryState({
             ...entryState,
             [e.target.name]: value
@@ -56,8 +143,11 @@ export default function AddEntryPage() {
     return (
         <div className="flex flex-col items-center justify-center h-screen">
             <h1 className="my-2">{entryState.type} Tracker</h1>
-            <form id="addEntry" className="flex flex-col items-left justify-center  bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4" action="#" onSubmit={addNewEntry}>
-                
+            <form 
+                id="addEntry" 
+                className="flex flex-col items-left justify-center  bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4" 
+                action="#" 
+                onSubmit={addNewEntry}>
                 <div>
                     <div className="radioInput">
                         
@@ -73,7 +163,7 @@ export default function AddEntryPage() {
                     </div>
                     
                     <div className="radioInput">
-                       
+                    
                         <input
                             id="type-anxiety"
                             type="radio"
@@ -82,7 +172,7 @@ export default function AddEntryPage() {
                             checked={entryState.type === "Anxiety"}
                             onChange={handleChange}
                         />
-                         <label forhtml="type-anxiety">Anxiety</label>
+                        <label forhtml="type-anxiety">Anxiety</label>
                     </div>
 
                     <div className="radioInput">
@@ -121,67 +211,79 @@ export default function AddEntryPage() {
                 
                 <div className="checkboxInput">
                 <input 
+                    index="0"
                     type="checkbox"
                     name="event" 
                     value="family"
-                    onChange={handleChange} 
+                    checked={isCheckedEventsArray[0]}
+                    onChange={(e) => handleChange(e, 0)} 
                 />
                 <label>Family problem</label>
                 </div>
 
             <div className="checkboxInput">
                 <input 
+                    index="1"
                     type="checkbox"
                     name="event" 
                     value="relationship"
-                    onChange={handleChange} 
+                    checked={isCheckedEventsArray[1]}
+                    onChange={(e) => handleChange(e, 1)}  
                 />
                 <label>Relationship problem</label>
             </div> 
 
             <div className="checkboxInput">
                 <input 
+                    index="2"
                     type="checkbox"
                     name="event" 
                     value="work"
-                    onChange={handleChange} 
+                    checked={isCheckedEventsArray[2]}
+                    onChange={(e) => handleChange(e, 2)}
                 />
                 <label>School or work</label>
-             </div>
+            </div>
 
-             <div className="checkboxInput">
+            <div className="checkboxInput">
                 <input 
+                    index="3"
                     type="checkbox"
                     name="event" 
                     value="significant"
-                    onChange={handleChange} 
+                    checked={isCheckedEventsArray[3]}
+                    onChange={(e) => handleChange(e, 3)}
                 />
                 <label>Significant life event</label>
             </div>
 
             <div className="checkboxInput">
                 <input 
+                    index="4"
                     type="checkbox"
                     name="event" 
                     value="trauma"
-                    onChange={handleChange} 
+                    checked={isCheckedEventsArray[4]}
+                    onChange={(e) => handleChange(e, 4)}
                 />
                 <label>A traumatic event</label>
                 </div> 
 
                 <div className="checkboxInput">
                 <input 
+                    index="5"
                     type="checkbox"
                     name="event" 
                     value="unknown"
-                    onChange={handleChange} 
+                    checked={isCheckedEventsArray[5]}
+                    onChange={(e) => handleChange(e, 5)}
                 />
                 <label>I am not sure</label>
                 </div>
                 
                 <label>Notes for today's entry (optional):</label>
 
-               <div className="flex flex-col items-center">
+                <div className="flex flex-col items-center">
                 <input className="self-stretch m-2 p-1"
                     
                     type="textarea"
@@ -189,7 +291,7 @@ export default function AddEntryPage() {
                     value={entryState.note}
                     onChange={handleChange} 
                 />
-             
+            
                 <input className="my-2 mx-2 px-4 py-2 leading-none  rounded text-white  hover:text-white bg-gradient-to-r from-green-300 to-blue-400 hover:from-cyan-200 hover:to-green-300 "
                     type="submit"
                     value="Add entry" 

--- a/client/src/components/AddEntryPage.js
+++ b/client/src/components/AddEntryPage.js
@@ -33,7 +33,6 @@ export default function AddEntryPage() {
      checkedPosition is the index of the checkboxes
     */
     const handleChange = (e, checkedPosition=0) => {
-        
         // Handle the checkboxes.
         if (e.target.name === "event") {
             // Checks or unchecks each checkbox and maps it to an array of booleans.
@@ -41,17 +40,6 @@ export default function AddEntryPage() {
                 index === checkedPosition ? !checkBoxState : checkBoxState
             );
             setIsCheckedEventsArray(updatedIsCheckedEventsArray);
-            
-            //let indexAttr = e.target.getAttribute('index');
-
-            console.log("==================================");
-            console.log("BEFORE");
-            console.log(updatedIsCheckedEventsArray)
-            console.log(e.target.name);
-            console.log("events:");
-            console.log(events);
-            //console.log(indexAttr);
-            //console.log(parseInt(indexAttr));
 
             // Transforms the array of booleans of the checkboxes to an array with values for each event.
             // checkBoxState is equal to the value of each item of boolean array
@@ -59,7 +47,6 @@ export default function AddEntryPage() {
             updatedIsCheckedEventsArray.forEach( (checkBoxState, index) => {
                 // Explicitly checking for true value to not make myself confused.
                 // same as if(checkBoxState) {}
-                console.log("index: " + index);
                 if (checkBoxState === true) {
                     // Each index corresponds to the checked or unchecked state of each of the 6 checkboxes.
                     switch(index) {
@@ -89,14 +76,6 @@ export default function AddEntryPage() {
                     events[index] = null;
                 }
             });
-
-            console.log("==================================");
-            console.log("AFTER");
-            console.log(updatedIsCheckedEventsArray)
-            console.log(e.target.name);
-            console.log("events:");
-            console.log(events);
-            
             // Set the event variable equal to the events array.
             setEntryState({
                 ...entryState,
@@ -131,7 +110,6 @@ export default function AddEntryPage() {
             event: entryState.event,
             notes: entryState.note
         };
-
         //Dispatch action to the global state to tell the server to add the new entry.
         dispatch(addEntry({username: username, entry: entryData}));
 
@@ -139,6 +117,16 @@ export default function AddEntryPage() {
         //Send user back to the dashboard after entry submit
         navigate("/dashboard");
     };
+
+    // For JSX rendering
+    const checkBoxLabels = [
+        "Family problem",
+        "Relationship problem",
+        "School or work",
+        "Significant life event",
+        "A traumatic event",
+        "I am not sure"
+    ];
 
     return (
         <div className="flex flex-col items-center justify-center h-screen">
@@ -209,77 +197,16 @@ export default function AddEntryPage() {
                 
                 <label className="py-4">Did anything in particular contribute to your elevated level of {entryState.type.toLowerCase()}?</label>
                 
-                <div className="checkboxInput">
-                <input 
-                    index="0"
-                    type="checkbox"
-                    name="event" 
-                    value="family"
-                    checked={isCheckedEventsArray[0]}
-                    onChange={(e) => handleChange(e, 0)} 
-                />
-                <label>Family problem</label>
-                </div>
-
-            <div className="checkboxInput">
-                <input 
-                    index="1"
-                    type="checkbox"
-                    name="event" 
-                    value="relationship"
-                    checked={isCheckedEventsArray[1]}
-                    onChange={(e) => handleChange(e, 1)}  
-                />
-                <label>Relationship problem</label>
-            </div> 
-
-            <div className="checkboxInput">
-                <input 
-                    index="2"
-                    type="checkbox"
-                    name="event" 
-                    value="work"
-                    checked={isCheckedEventsArray[2]}
-                    onChange={(e) => handleChange(e, 2)}
-                />
-                <label>School or work</label>
-            </div>
-
-            <div className="checkboxInput">
-                <input 
-                    index="3"
-                    type="checkbox"
-                    name="event" 
-                    value="significant"
-                    checked={isCheckedEventsArray[3]}
-                    onChange={(e) => handleChange(e, 3)}
-                />
-                <label>Significant life event</label>
-            </div>
-
-            <div className="checkboxInput">
-                <input 
-                    index="4"
-                    type="checkbox"
-                    name="event" 
-                    value="trauma"
-                    checked={isCheckedEventsArray[4]}
-                    onChange={(e) => handleChange(e, 4)}
-                />
-                <label>A traumatic event</label>
-                </div> 
-
-                <div className="checkboxInput">
-                <input 
-                    index="5"
-                    type="checkbox"
-                    name="event" 
-                    value="unknown"
-                    checked={isCheckedEventsArray[5]}
-                    onChange={(e) => handleChange(e, 5)}
-                />
-                <label>I am not sure</label>
-                </div>
+                {[0,1,2,3,4,5].map((index) => 
+                    <div className="checkboxInput" key={index}>
+                        <input 
+                            type="checkbox"
+                            name="event" 
+                            checked={isCheckedEventsArray[index]}
+                            onChange={(e) => handleChange(e, index)} 
+                        />
+                        <label>{checkBoxLabels[index]}</label>
+                    </div>)}
                 
                 <label>Notes for today's entry (optional):</label>
 

--- a/client/src/components/Entry.js
+++ b/client/src/components/Entry.js
@@ -18,15 +18,11 @@ export default function Entry(props) {
             <hr />
             <p><strong>Type: </strong>{props.entryInfo.type}</p>
             <p><strong>Level: </strong>{props.entryInfo.level}</p>
-            <p><strong>Events: </strong> 
-            {props.entryInfo.event.filter(item => item !== null).map((item, index) => 
-                <span key={index}>{`${item}, `}</span>)}
-            </p>
+            <p><strong>Events: </strong> {props.entryInfo.event.filter(item => item !== null).join(", ")}</p>
             <p><strong>Notes: </strong>{props.entryInfo.notes}</p>
             <button>Edit</button>
             <button onClick={deleteEntryOnClick}>Delete</button>
         </div>
     )
 }
-
 

--- a/client/src/components/Entry.js
+++ b/client/src/components/Entry.js
@@ -12,22 +12,21 @@ export default function Entry(props) {
         dispatch(deleteEntry({username: username, entryId: props.entryInfo.entryId}));
     };
 
-    /*  
-        There is a bug here where if the events are more than 1,
-        it displays "Unknown"
-    */
-
     return (
         <div className="entryCard">
             <h4>Date Created: {props.entryInfo.date}</h4>
             <hr />
             <p><strong>Type: </strong>{props.entryInfo.type}</p>
             <p><strong>Level: </strong>{props.entryInfo.level}</p>
-            <p><strong>Events: </strong>{props.entryInfo.event}</p>
+            <p><strong>Events: </strong> 
+            {props.entryInfo.event.filter(item => item !== null).map((item, index) => 
+                <span key={index}>{`${item}, `}</span>)}
+            </p>
             <p><strong>Notes: </strong>{props.entryInfo.notes}</p>
             <button>Edit</button>
             <button onClick={deleteEntryOnClick}>Delete</button>
         </div>
     )
 }
+
 


### PR DESCRIPTION
There was a bug on the ViewEntriesPage.js inside Entry.js  
The bug was that only 1 event would be shown. Even if the user added multiple events to their entry in AddEntryPage.js

The problem was in the AddEntryPage.js. Even if the user selected multiple event checkboxes. Only 1 would actually register and be stored on the server.

Took me about 3 hours and a lot of trial and errors to finally fix this haha. But I learned a lot.
Not sure if its the most elegant code, but it works. I tried 3 different variations of the code, but none worked.

The solution was to map all the check boxes individual checked or unchecked states into a boolean array.
Then check which ones are checked and unchecked and map that to actual strings of what the event is.

There is now a new bug where the comma is still shown after the last event. 